### PR TITLE
Enhancment/16 split mtproto

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,38 +3,27 @@ package mtproto
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 )
 
 func (m *MTProto) AuthSendCode(phonenumber string) (*TL_auth_sentCode, error) {
 	var authSentCode TL_auth_sentCode
-	flag := true
-	for flag {
-		x := <-m.InvokeAsync(TL_auth_sendCode{
-			Allow_flashcall: false,
-			Phone_number:    phonenumber,
-			Current_number:  TL_boolTrue{},
-			Api_id:          m.appConfig.Id,
-			Api_hash:        m.appConfig.Hash,
-		})
+	tl, err := m.InvokeSync(TL_auth_sendCode{
+		Allow_flashcall: false,
+		Phone_number:    phonenumber,
+		Current_number:  TL_boolTrue{},
+		Api_id:          m.appConfig.Id,
+		Api_hash:        m.appConfig.Hash,
+	})
 
-		if x.err != nil {
-			// TODO: Maybe there are different ways to do it
-			// MTProto connected to new DC(see handleRPCError), trying to get data again
-			if strings.Contains(x.err.Error(), strconv.Itoa(errorSeeOther)) {
-				continue
-			}
-			return nil, x.err
-		}
+	if err != nil {
+		return nil, err
+	}
 
-		switch x.data.(type) {
-		case TL_auth_sentCode:
-			authSentCode = x.data.(TL_auth_sentCode)
-			flag = false
-		default:
-			return nil, fmt.Errorf("Got: %T", x)
-		}
+	switch (*tl).(type) {
+	case TL_auth_sentCode:
+		authSentCode = (*tl).(TL_auth_sentCode)
+	default:
+		return nil, fmt.Errorf("Got: %T", *tl)
 	}
 
 	return &authSentCode, nil
@@ -45,19 +34,20 @@ func (m *MTProto) AuthSignIn(phoneNumber, phoneCode, phoneCodeHash string) (*TL_
 		return nil, errors.New("MRProto::AuthSignIn one of function parameters is empty")
 	}
 
-	x := <-m.InvokeAsync(TL_auth_signIn{
+	tl, err := m.InvokeSync(TL_auth_signIn{
 		Phone_number:    phoneNumber,
 		Phone_code_hash: phoneCodeHash,
 		Phone_code:      phoneCode,
 	})
-	if x.err != nil {
-		return nil, x.err
+
+	if err != nil {
+		return nil, err
 	}
 
-	auth, ok := x.data.(TL_auth_authorization)
+	auth, ok := (*tl).(TL_auth_authorization)
 
 	if !ok {
-		return nil, fmt.Errorf("RPC: %#v", x)
+		return nil, fmt.Errorf("RPC: %#v", *tl)
 	}
 
 	return &auth, nil
@@ -65,12 +55,13 @@ func (m *MTProto) AuthSignIn(phoneNumber, phoneCode, phoneCodeHash string) (*TL_
 
 func (m *MTProto) AuthLogOut() (bool, error) {
 	var result bool
-	x := <-m.InvokeAsync(TL_auth_logOut{})
-	if x.err != nil {
-		return result, x.err
+
+	tl, err := m.InvokeSync(TL_auth_logOut{})
+	if err != nil {
+		return result, err
 	}
 
-	result, err := ToBool(x.data)
+	result, err = ToBool(*tl)
 	if err != nil {
 		return result, err
 	}

--- a/contacts.go
+++ b/contacts.go
@@ -9,7 +9,7 @@ func (m *MTProto) ContactsGetContacts(hash string) (*TL, error) {
 }
 
 func (m *MTProto) ContactsGetTopPeers(correspondents, botsPM, botsInline, groups, channels bool, offset, limit, hash int32) (*TL, error) {
-	x := <-m.InvokeAsync(TL_contacts_getTopPeers{
+	tl, err := m.InvokeSync(TL_contacts_getTopPeers{
 		Correspondents: correspondents,
 		Bots_pm:        botsPM,
 		Bots_inline:    botsInline,
@@ -20,16 +20,16 @@ func (m *MTProto) ContactsGetTopPeers(correspondents, botsPM, botsInline, groups
 		Hash:           hash,
 	})
 
-	if x.err != nil {
-		return nil, x.err
+	if err != nil {
+		return nil, err
 	}
 
-	switch x.data.(type) {
+	switch (*tl).(type) {
 	case TL_contacts_topPeersNotModified:
 	case TL_contacts_topPeers:
 	default:
 		return nil, errors.New("MTProto::ContactsGetTopPeers error: Unknown type")
 	}
 
-	return &x.data, nil
+	return tl, nil
 }

--- a/network.go
+++ b/network.go
@@ -5,10 +5,82 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net"
+	"sync"
 	"time"
 )
 
-func (m *MTProto) sendPacket(msg TL, resp chan response) error {
+// low-level communication with telegram server
+type INetwork interface {
+	Connect() error
+	Disconnect() error
+	Send(msg TL, resp chan response) error
+	Read() (interface{}, error)
+	Process(data interface{}) interface{}
+}
+
+type Network struct {
+	session ISession
+
+	conn *net.TCPConn
+
+	mutex        *sync.Mutex
+	msgsIdToAck  map[int64]packetToSend
+	msgsIdToResp map[int64]chan response
+
+	queueSend chan packetToSend
+	lastSeqNo int32
+	seqNo     int32
+	msgId     int64
+}
+
+func NewNetwork(session ISession, queueSend chan packetToSend) INetwork {
+	nw := new(Network)
+
+	nw.session = session
+	nw.queueSend = queueSend
+	nw.msgsIdToAck = make(map[int64]packetToSend)
+	nw.msgsIdToResp = make(map[int64]chan response)
+	nw.mutex = &sync.Mutex{}
+
+	return nw
+}
+
+func (nw *Network) Connect() error {
+	var err error
+	var tcpAddr *net.TCPAddr
+
+	// connect
+	tcpAddr, err = net.ResolveTCPAddr("tcp", nw.session.GetAddress())
+	if err != nil {
+		return err
+	}
+	nw.conn, err = net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return err
+	}
+	// Packet Length is encoded by a single byte (see: https://core.telegram.org/mtproto)
+	_, err = nw.conn.Write([]byte{0xef})
+	if err != nil {
+		return err
+	}
+	// get new authKey if need
+	if !nw.session.IsEncrypted() {
+		err = nw.makeAuthKey()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (nw *Network) Disconnect() error {
+
+	return nw.conn.Close()
+}
+
+func (nw *Network) Send(msg TL, resp chan response) error {
 	obj := msg.encode()
 
 	x := NewEncodeBuf(256)
@@ -16,7 +88,7 @@ func (m *MTProto) sendPacket(msg TL, resp chan response) error {
 	// padding for tcpsize
 	x.Int(0)
 
-	if m.session.IsEncrypted() {
+	if nw.session.IsEncrypted() {
 		needAck := true
 		switch msg.(type) {
 		case TL_ping, TL_msgs_ack:
@@ -24,19 +96,19 @@ func (m *MTProto) sendPacket(msg TL, resp chan response) error {
 		}
 		z := NewEncodeBuf(256)
 		newMsgId := GenerateMessageId()
-		z.Bytes(m.session.GetServerSalt())
-		z.Long(m.session.GetSessionID())
+		z.Bytes(nw.session.GetServerSalt())
+		z.Long(nw.session.GetSessionID())
 		z.Long(newMsgId)
 		if needAck {
-			z.Int(m.lastSeqNo | 1)
+			z.Int(nw.lastSeqNo | 1)
 		} else {
-			z.Int(m.lastSeqNo)
+			z.Int(nw.lastSeqNo)
 		}
 		z.Int(int32(len(obj)))
 		z.Bytes(obj)
 
 		msgKey := sha1(z.buf)[4:20]
-		aesKey, aesIV := generateAES(msgKey, m.session.GetAuthKey(), false)
+		aesKey, aesIV := generateAES(msgKey, nw.session.GetAuthKey(), false)
 
 		y := make([]byte, len(z.buf)+((16-(len(obj)%16))&15))
 		copy(y, z.buf)
@@ -45,21 +117,21 @@ func (m *MTProto) sendPacket(msg TL, resp chan response) error {
 			return err
 		}
 
-		m.lastSeqNo += 2
+		nw.lastSeqNo += 2
 		if needAck {
-			m.mutex.Lock()
-			m.msgsIdToAck[newMsgId] = packetToSend{msg, resp}
-			m.mutex.Unlock()
+			nw.mutex.Lock()
+			nw.msgsIdToAck[newMsgId] = packetToSend{msg, resp}
+			nw.mutex.Unlock()
 		}
 
-		x.Bytes(m.session.GetAuthKeyHash())
+		x.Bytes(nw.session.GetAuthKeyHash())
 		x.Bytes(msgKey)
 		x.Bytes(encryptedData)
 
 		if resp != nil {
-			m.mutex.Lock()
-			m.msgsIdToResp[newMsgId] = resp
-			m.mutex.Unlock()
+			nw.mutex.Lock()
+			nw.msgsIdToResp[newMsgId] = resp
+			nw.mutex.Unlock()
 		}
 
 	} else {
@@ -79,7 +151,7 @@ func (m *MTProto) sendPacket(msg TL, resp chan response) error {
 	} else {
 		binary.LittleEndian.PutUint32(x.buf, uint32(size<<8|127))
 	}
-	_, err := m.conn.Write(x.buf)
+	_, err := nw.conn.Write(x.buf)
 	if err != nil {
 		return err
 	}
@@ -87,18 +159,18 @@ func (m *MTProto) sendPacket(msg TL, resp chan response) error {
 	return nil
 }
 
-func (m *MTProto) read() (interface{}, error) {
+func (nw *Network) Read() (interface{}, error) {
 	var err error
 	var n int
 	var size int
 	var data interface{}
 
-	err = m.conn.SetReadDeadline(time.Now().Add(300 * time.Second))
+	err = nw.conn.SetReadDeadline(time.Now().Add(300 * time.Second))
 	if err != nil {
 		return nil, err
 	}
 	b := make([]byte, 1)
-	n, err = m.conn.Read(b)
+	n, err = nw.conn.Read(b)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +179,7 @@ func (m *MTProto) read() (interface{}, error) {
 		size = int(b[0]) << 2
 	} else {
 		b := make([]byte, 3)
-		n, err = m.conn.Read(b)
+		n, err = nw.conn.Read(b)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +189,7 @@ func (m *MTProto) read() (interface{}, error) {
 	left := size
 	buf := make([]byte, size)
 	for left > 0 {
-		n, err = m.conn.Read(buf[size-left:])
+		n, err = nw.conn.Read(buf[size-left:])
 		if err != nil {
 			return nil, err
 		}
@@ -132,12 +204,12 @@ func (m *MTProto) read() (interface{}, error) {
 
 	authKeyHash := dbuf.Bytes(8)
 	if binary.LittleEndian.Uint64(authKeyHash) == 0 {
-		m.msgId = dbuf.Long()
+		nw.msgId = dbuf.Long()
 		messageLen := dbuf.Int()
 		if int(messageLen) != dbuf.size-20 {
 			return nil, fmt.Errorf("Message len: %d (need %d)", messageLen, dbuf.size-20)
 		}
-		m.seqNo = 0
+		nw.seqNo = 0
 
 		data = dbuf.Object()
 		if dbuf.err != nil {
@@ -147,7 +219,7 @@ func (m *MTProto) read() (interface{}, error) {
 	} else {
 		msgKey := dbuf.Bytes(16)
 		encryptedData := dbuf.Bytes(dbuf.size - 24)
-		aesKey, aesIV := generateAES(msgKey, m.session.GetAuthKey(), true)
+		aesKey, aesIV := generateAES(msgKey, nw.session.GetAuthKey(), true)
 		x, err := doAES256IGEdecrypt(encryptedData, aesKey, aesIV)
 		if err != nil {
 			return nil, err
@@ -155,8 +227,8 @@ func (m *MTProto) read() (interface{}, error) {
 		dbuf = NewDecodeBuf(x)
 		_ = dbuf.Long() // salt
 		_ = dbuf.Long() // session_id
-		m.msgId = dbuf.Long()
-		m.seqNo = dbuf.Int()
+		nw.msgId = dbuf.Long()
+		nw.seqNo = dbuf.Int()
 		messageLen := dbuf.Int()
 		if int(messageLen) > dbuf.size-32 {
 			return nil, fmt.Errorf("Message len: %d (need less than %d)", messageLen, dbuf.size-32)
@@ -171,7 +243,7 @@ func (m *MTProto) read() (interface{}, error) {
 		}
 
 	}
-	mod := m.msgId & 3
+	mod := nw.msgId & 3
 	if mod != 1 && mod != 3 {
 		return nil, fmt.Errorf("Wrong bits of message_id: %d", mod)
 	}
@@ -179,20 +251,20 @@ func (m *MTProto) read() (interface{}, error) {
 	return data, nil
 }
 
-func (m *MTProto) makeAuthKey() error {
+func (nw *Network) makeAuthKey() error {
 	var x []byte
 	var err error
 	var data interface{}
 
 	// (send) req_pq
 	nonceFirst := GenerateNonce(16)
-	err = m.sendPacket(TL_req_pq{nonceFirst}, nil)
+	err = nw.Send(TL_req_pq{nonceFirst}, nil)
 	if err != nil {
 		return err
 	}
 
 	// (parse) resPQ
-	data, err = m.read()
+	data, err = nw.Read()
 	if err != nil {
 		return err
 	}
@@ -225,13 +297,13 @@ func (m *MTProto) makeAuthKey() error {
 	copy(x[20:], innerData1)
 	encryptedData1 := doRSAencrypt(x)
 	// (send) req_DH_params
-	err = m.sendPacket(TL_req_DH_params{nonceFirst, nonceServer, p, q, telegramPublicKey_FP, encryptedData1}, nil)
+	err = nw.Send(TL_req_DH_params{nonceFirst, nonceServer, p, q, telegramPublicKey_FP, encryptedData1}, nil)
 	if err != nil {
 		return err
 	}
 
 	// (parse) server_DH_params_{ok, fail}
-	data, err = m.read()
+	data, err = nw.Read()
 	if err != nil {
 		return err
 	}
@@ -306,9 +378,9 @@ func (m *MTProto) makeAuthKey() error {
 	copy(serverSalt, nonceSecond[:8])
 	xor(serverSalt, nonceServer[:8])
 
-	m.session.SetAuthKey(authKey)
-	m.session.SetAuthKeyHash(authKeyHash)
-	m.session.SetServerSalt(serverSalt)
+	nw.session.SetAuthKey(authKey)
+	nw.session.SetAuthKeyHash(authKeyHash)
+	nw.session.SetServerSalt(serverSalt)
 
 	// (encoding) client_DH_inner_data
 	innerData2 := (TL_client_DH_inner_data{nonceFirst, nonceServer, 0, g_b}).encode()
@@ -318,13 +390,13 @@ func (m *MTProto) makeAuthKey() error {
 	encryptedData2, err := doAES256IGEencrypt(x, tmpAESKey, tmpAESIV)
 
 	// (send) set_client_DH_params
-	err = m.sendPacket(TL_set_client_DH_params{nonceFirst, nonceServer, encryptedData2}, nil)
+	err = nw.Send(TL_set_client_DH_params{nonceFirst, nonceServer, encryptedData2}, nil)
 	if err != nil {
 		return err
 	}
 
 	// (parse) dh_gen_{ok, Retry, fail}
-	data, err = m.read()
+	data, err = nw.Read()
 	if err != nil {
 		return err
 	}
@@ -343,11 +415,77 @@ func (m *MTProto) makeAuthKey() error {
 	}
 
 	// (all ok)
-	err = m.session.Save()
+	err = nw.session.Save()
 	if err != nil {
 		return err
 	}
-	m.session.Encrypted(true)
+	nw.session.Encrypted(true)
+
+	return nil
+}
+
+func (nw *Network) Process(data interface{}) interface{} {
+	return nw.process(nw.msgId, nw.seqNo, data)
+}
+
+func (nw *Network) process(msgId int64, seqNo int32, data interface{}) interface{} {
+	switch data.(type) {
+	case TL_msg_container:
+		data := data.(TL_msg_container).Items
+		for _, v := range data {
+			nw.process(v.Msg_id, v.Seq_no, v.Data)
+		}
+
+	case TL_bad_server_salt:
+		data := data.(TL_bad_server_salt)
+		nw.session.SetServerSalt(data.New_server_salt)
+		_ = nw.session.Save()
+		nw.mutex.Lock()
+		defer nw.mutex.Unlock()
+		for k, v := range nw.msgsIdToAck {
+			delete(nw.msgsIdToAck, k)
+			nw.queueSend <- v
+		}
+
+	case TL_new_session_created:
+		data := data.(TL_new_session_created)
+		nw.session.SetServerSalt(data.Server_salt)
+		_ = nw.session.Save()
+
+	case TL_ping:
+		data := data.(TL_ping)
+		nw.queueSend <- packetToSend{TL_pong{msgId, data.Ping_id}, nil}
+
+	case TL_pong:
+		// ignore
+
+	case TL_msgs_ack:
+		data := data.(TL_msgs_ack)
+		nw.mutex.Lock()
+		defer nw.mutex.Unlock()
+		for _, v := range data.MsgIds {
+			delete(nw.msgsIdToAck, v)
+		}
+
+	case TL_rpc_result:
+		data := data.(TL_rpc_result)
+		x := nw.process(msgId, seqNo, data.Obj)
+		nw.mutex.Lock()
+		defer nw.mutex.Unlock()
+		if v, ok := nw.msgsIdToResp[data.Req_msg_id]; ok {
+			// TODO: response struct is useless
+			v <- response{x.(TL), nil}
+			close(v)
+		}
+		delete(nw.msgsIdToAck, data.Req_msg_id)
+	default:
+		return data
+	}
+
+	// TODO: Check why I should do this
+	if (seqNo & 1) == 1 {
+		nw.queueSend <- packetToSend{TL_msgs_ack{[]int64{msgId}}, nil}
+	}
 
 	return nil
 }

--- a/network.go
+++ b/network.go
@@ -525,8 +525,13 @@ func (nw *Network) process(msgId int64, seqNo int32, data interface{}) interface
 		nw.mutex.Lock()
 		defer nw.mutex.Unlock()
 		if v, ok := nw.msgsIdToResp[data.Req_msg_id]; ok {
-			// TODO: response struct is useless
-			v <- response{x.(TL), nil}
+			var resp response
+			if rpcError, ok := x.(TL_rpc_error); ok {
+				resp.err = rpcError
+			}
+			resp.data = x.(TL)
+			v <- resp
+
 			close(v)
 		}
 		delete(nw.msgsIdToAck, data.Req_msg_id)

--- a/session.go
+++ b/session.go
@@ -1,0 +1,163 @@
+package mtproto
+
+import (
+	"errors"
+	"os"
+)
+
+// Session storage interface
+type ISession interface {
+	// Load is deserialization method
+	Load() error
+	// Save is serialization method
+	Save() error
+
+	IsIPv6() bool
+	// IsEncrypted returns true if AuthKey, ServerSalt and SessionID fields aren't empty
+	IsEncrypted() bool
+
+	GetAddress() string
+	GetAuthKey() []byte
+	GetAuthKeyHash() []byte
+	GetServerSalt() []byte
+	GetSessionID() int64
+
+	SetAddress(string)
+	SetAuthKey([]byte)
+	SetAuthKeyHash([]byte)
+	SetServerSalt([]byte)
+	SetSessionID(int64)
+
+	UseIPv6(bool)
+	Encrypted(bool)
+}
+
+type Session struct {
+	// TODO: ReaderWriter interface
+	file *os.File
+
+	address     string
+	authKey     []byte
+	authKeyHash []byte
+	serverSalt  []byte
+	sessionId   int64
+	useIPv6     bool
+	encrypted   bool
+}
+
+func NewSession(file *os.File) ISession {
+	return &Session{
+		file: file,
+	}
+}
+
+func (s *Session) Load() error {
+	// TODO: Magic number
+	buffer := make([]byte, 1024*4)
+	n, _ := s.file.ReadAt(buffer, 0)
+	if n <= 0 {
+		return errors.New("New session")
+	}
+
+	decoder := NewDecodeBuf(buffer)
+	s.authKey = decoder.StringBytes()
+	s.authKeyHash = decoder.StringBytes()
+	s.serverSalt = decoder.StringBytes()
+	s.address = decoder.String()
+	s.useIPv6 = false
+	if decoder.UInt() == 1 {
+		s.useIPv6 = true
+	}
+
+	if decoder.err != nil {
+		return decoder.err
+	}
+
+	return nil
+}
+
+func (s Session) Save() error {
+	// TODO: Magic number
+	buffer := NewEncodeBuf(1024)
+	buffer.StringBytes(s.authKey)
+	buffer.StringBytes(s.authKeyHash)
+	buffer.StringBytes(s.serverSalt)
+	buffer.String(s.address)
+
+	var useIPv6UInt uint32
+	if s.useIPv6 {
+		useIPv6UInt = 1
+	}
+	buffer.UInt(useIPv6UInt)
+
+	err := s.file.Truncate(0)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.file.WriteAt(buffer.buf, 0)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s Session) IsIPv6() bool {
+	return s.useIPv6
+}
+
+func (s Session) IsEncrypted() bool {
+	return s.encrypted
+}
+
+func (s Session) GetAddress() string {
+	return s.address
+}
+
+func (s Session) GetAuthKey() []byte {
+	return s.authKey
+}
+
+func (s Session) GetAuthKeyHash() []byte {
+	return s.authKeyHash
+}
+
+func (s Session) GetServerSalt() []byte {
+	return s.serverSalt
+}
+
+func (s Session) GetSessionID() int64 {
+	return s.sessionId
+}
+
+func (s *Session) SetAddress(address string) {
+	s.address = address
+}
+
+func (s *Session) SetAuthKey(authKey []byte) {
+	s.authKey = make([]byte, len(authKey))
+	copy(s.authKey, authKey)
+}
+
+func (s *Session) SetAuthKeyHash(authKeyHash []byte) {
+	s.authKeyHash = make([]byte, len(authKeyHash))
+	copy(s.authKeyHash, authKeyHash)
+}
+
+func (s *Session) SetServerSalt(salt []byte) {
+	s.serverSalt = make([]byte, len(salt))
+	copy(s.serverSalt, salt)
+}
+
+func (s *Session) SetSessionID(ID int64) {
+	s.sessionId = ID
+}
+
+func (s *Session) UseIPv6(useIPv6 bool) {
+	s.useIPv6 = useIPv6
+}
+
+func (s *Session) Encrypted(encrypted bool) {
+	s.encrypted = encrypted
+}

--- a/session.go
+++ b/session.go
@@ -3,6 +3,8 @@ package mtproto
 import (
 	"errors"
 	"os"
+	"math/rand"
+	"time"
 )
 
 // Session storage interface
@@ -46,9 +48,14 @@ type Session struct {
 }
 
 func NewSession(file *os.File) ISession {
-	return &Session{
+	session := &Session{
 		file: file,
 	}
+
+	rand.Seed(time.Now().UnixNano())
+	session.SetSessionID(rand.Int63())
+
+	return session
 }
 
 func (s *Session) Load() error {

--- a/types.go
+++ b/types.go
@@ -147,6 +147,10 @@ type TL_rpc_error struct {
 	Error_message string
 }
 
+func (err TL_rpc_error) Error() string {
+	return err.Error_message
+}
+
 const crc_dh_gen_ok = 0x3bcbf734
 
 type TL_dh_gen_ok struct {

--- a/users.go
+++ b/users.go
@@ -4,18 +4,18 @@ import "fmt"
 
 func (m *MTProto) UsersGetFullUsers(id TL) (*TL_userFull, error) {
 	var user TL_userFull
-	x := <-m.InvokeAsync(TL_users_getFullUser{
+	tl, err := m.InvokeSync(TL_users_getFullUser{
 		Id: id,
 	})
-	if x.err != nil {
-		return nil, x.err
+	if err != nil {
+		return nil, err
 	}
 
-	switch x.data.(type) {
+	switch (*tl).(type) {
 	case TL_userFull:
-		user = x.data.(TL_userFull)
+		user = (*tl).(TL_userFull)
 	default:
-		return nil, fmt.Errorf("Got: %T", x)
+		return nil, fmt.Errorf("Got: %T", *tl)
 	}
 
 	return &user, nil


### PR DESCRIPTION
MTProto splited in three entities:
1. MTProto - main class
2. Network - send, read and process messages from DC
3. Session - stores session (too ugly, will refactor in future)